### PR TITLE
forward plugin stderr to host without hclog

### DIFF
--- a/client.go
+++ b/client.go
@@ -1082,78 +1082,11 @@ func (c *Client) logStderr(name string, r io.Reader) {
 	defer c.stderrWaitGroup.Done()
 	l := c.logger.Named(filepath.Base(name))
 
-	reader := bufio.NewReaderSize(r, stdErrBufferSize)
-	// continuation indicates the previous line was a prefix
-	continuation := false
-
 	for {
-		line, isPrefix, err := reader.ReadLine()
-		switch {
-		case err == io.EOF:
-			return
-		case err != nil:
-			l.Error("reading plugin stderr", "error", err)
-			return
-		}
-
-		c.config.Stderr.Write(line)
-
-		// The line was longer than our max token size, so it's likely
-		// incomplete and won't unmarshal.
-		if isPrefix || continuation {
-			l.Debug(string(line))
-
-			// if we're finishing a continued line, add the newline back in
-			if !isPrefix {
-				c.config.Stderr.Write([]byte{'\n'})
-			}
-
-			continuation = isPrefix
-			continue
-		}
-
-		c.config.Stderr.Write([]byte{'\n'})
-
-		entry, err := parseJSON(line)
-		// If output is not JSON format, print directly to Debug
+		_, err := io.Copy(c.config.Stderr, r)
 		if err != nil {
-			// Attempt to infer the desired log level from the commonly used
-			// string prefixes
-			switch line := string(line); {
-			case strings.HasPrefix(line, "[TRACE]"):
-				l.Trace(line)
-			case strings.HasPrefix(line, "[DEBUG]"):
-				l.Debug(line)
-			case strings.HasPrefix(line, "[INFO]"):
-				l.Info(line)
-			case strings.HasPrefix(line, "[WARN]"):
-				l.Warn(line)
-			case strings.HasPrefix(line, "[ERROR]"):
-				l.Error(line)
-			default:
-				l.Debug(line)
-			}
-		} else {
-			out := flattenKVPairs(entry.KVPairs)
-
-			out = append(out, "timestamp", entry.Timestamp.Format(hclog.TimeFormat))
-			switch hclog.LevelFromString(entry.Level) {
-			case hclog.Trace:
-				l.Trace(entry.Message, out...)
-			case hclog.Debug:
-				l.Debug(entry.Message, out...)
-			case hclog.Info:
-				l.Info(entry.Message, out...)
-			case hclog.Warn:
-				l.Warn(entry.Message, out...)
-			case hclog.Error:
-				l.Error(entry.Message, out...)
-			default:
-				// if there was no log level, it's likely this is unexpected
-				// json from something other than hclog, and we should output
-				// it verbatim.
-				l.Debug(string(line))
-			}
+			l.Error("Error copying data to stderr:", err)
 		}
 	}
+
 }


### PR DESCRIPTION
To stream agent logs over grpc with the Opni CLI, I have a custom logger in https://github.com/rancher/opni/pull/1774 that logs plugin grpc messages to the plugin `stderr`, which go-plugin forwards to the agent host process in `logStderr`. The logs from the agent host process are then streamed to the gateway.

By default, go-plugin takes everything written to `stderr` and attempts to log it as a structured hclog log. If hclog parsing fails, it casts the output as a string before forwarding to the host (`l.Debug(string(line))`). My grpc `[]byte` message is casted to a string which causes undefined behaviour. Instead, I'd like to directly forward everything from the plugin stderr without the hclog parsing.